### PR TITLE
rename frontend-configs and add markdown rules to editorconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Guidelines, recommendations, linting, formating and IDE configs provided and use
 - [Node Dependency Management](general/dependency-management.md)
 - [Code Review Rules](general/Code-review-rules.md)
 - [Front-end Security Guidelines](general/front-end-security-guidelines.md)
-- [Front-end Tools Configurations](general/front-end-configs.md)
+- [Coding Tools Configurations](general/coding-tools-configs.md)

--- a/general/coding-tools-configs.md
+++ b/general/coding-tools-configs.md
@@ -1,6 +1,6 @@
-# Avenga Frontend Configs
+# Avenga Coding Tools Configs
 
-This file contains baseline configurations for Avenga tools commonly used when developing frontends.
+This file contains baseline configurations for tool assisted developing at Avenga.
 
 Table of contents:
 
@@ -24,6 +24,11 @@ end_of_line = lf
 charset = utf-8
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+# markdown syntax is incompatible with trimmed whitespace
+[*.md]
+insert_final_newline = false
+trim_trailing_whitespace = false
 ```
 
 ## Prettier


### PR DESCRIPTION
We are not a pure frontend company and many of these tools reflect tools to assist in any project, nut just frontend coding.

So I propose to change the name (other naming ideas are welcome).

Also markdown files have a special meaning for end of line whitespaces so we should absolutely not trim them.